### PR TITLE
Fix subscribers do not receive all events when events are published

### DIFF
--- a/billing_service/billing_service.py
+++ b/billing_service/billing_service.py
@@ -33,7 +33,7 @@ def create_billing(_order_id):
 
 def order_created(item):
     try:
-        msg_data = json.loads(item[1][0][1]['entity'])
+        msg_data = json.loads(item['entity'])
         customer = store.find_one('customer', msg_data['customer_id'])
         products = [store.find_one('product', product_id) for product_id in msg_data['product_ids']]
         msg = """Dear {}!
@@ -52,7 +52,7 @@ Cheers""".format(customer['name'], sum([int(product['price']) for product in pro
 
 def billing_created(item):
     try:
-        msg_data = json.loads(item[1][0][1]['entity'])
+        msg_data = json.loads(item['entity'])
         order = store.find_one('order', msg_data['order_id'])
         customer = store.find_one('customer', order['customer_id'])
         products = [store.find_one('product', product_id) for product_id in order['product_ids']]

--- a/crm_service/crm_service.py
+++ b/crm_service/crm_service.py
@@ -12,7 +12,7 @@ store = EventStore()
 
 def customer_created(item):
     try:
-        msg_data = json.loads(item[1][0][1]['entity'])
+        msg_data = json.loads(item['entity'])
         msg = """Dear {}!
 
 Welcome to Ordershop.
@@ -29,7 +29,7 @@ Cheers""".format(msg_data['name'])
 
 def customer_deleted(item):
     try:
-        msg_data = json.loads(item[1][0][1]['entity'])
+        msg_data = json.loads(item['entity'])
         msg = """Dear {}!
 
 Good bye, hope to see you soon again at Ordershop.
@@ -46,7 +46,7 @@ Cheers""".format(msg_data['name'])
 
 def order_created(item):
     try:
-        msg_data = json.loads(item[1][0][1]['entity'])
+        msg_data = json.loads(item['entity'])
         customer = store.find_one('customer', msg_data['customer_id'])
         products = [store.find_one('product', product_id) for product_id in msg_data['product_ids']]
         msg = """Dear {}!


### PR DESCRIPTION
while the subscriber is still processing the last event.

When polling the events from the stream via `items = self.redis.xread`,
`items` is a list which contains a list for each stream defined in streams.
Therefore `for item in items:` actually iterates the streams (which is only one here) and not the events.
When the events are processed later by `item[1][0][1]` we only select the very first event and discard all the others, if there are more.

You can see this when you simulate a heavy processing while processing the events by adding 
`time.sleep(.1)` to the `EventStore._entity_created` method for example.
 